### PR TITLE
Added gray placeholder image

### DIFF
--- a/src/Components/Thumbnail/index.js
+++ b/src/Components/Thumbnail/index.js
@@ -7,7 +7,7 @@ import * as thumbnail from './thumbnail.module.scss'
 const Thumbnail = ({ image, title, subtitles, id, category }) => {
   const filterImages = image => {
     if (image) return image.medium;
-    return 'http://placekitten.com/250/250'
+    return 'https://via.placeholder.com/300x250.png?text=Image+Unavailable'
   }
 
   const maxLen = (str, max) => {

--- a/src/Components/Thumbnail/thumbnail.module.scss
+++ b/src/Components/Thumbnail/thumbnail.module.scss
@@ -7,7 +7,7 @@ $gutter-desktop: 32px;
   -moz-box-shadow: 0 0 7px #ccc;
   -webkit-box-shadow: 0 0 7px #ccc;
   box-shadow: 0 0 7px #aaa;
-  margin: 2rem $thumbnail-gutter ;
+  margin: 2rem $thumbnail-gutter;
 
   &:hover {
     background-color: #eee;
@@ -49,4 +49,8 @@ $gutter-desktop: 32px;
   @media (min-width: 1300px) {
     width: calc(25% - (#{$gutter-desktop} * 2))
   }
+}
+
+a {
+  text-decoration: none;
 }


### PR DESCRIPTION
This commit adds a plain placeholder image when there is no image
available. This makes it easier to tell  it is a ph image.

This commit also removes underlines under Thumbnail text.